### PR TITLE
Make downloaded songs show up in UI :)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/EditDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/EditDialog.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.musicplayer.dialogs
 import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
+import android.os.Environment
 import android.provider.MediaStore
 import android.support.v7.app.AlertDialog
 import android.view.LayoutInflater
@@ -42,7 +43,7 @@ class EditDialog(val activity: SimpleActivity, val song: Song, val callback: (So
                     return@setOnClickListener
                 }
 
-                val uri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+                val uri = android.net.Uri.fromFile(Environment.getDataDirectory())
                 song.artist = newArtist
                 song.title = newTitle
 

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/models/Events.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/models/Events.kt
@@ -1,8 +1,13 @@
 package com.simplemobiletools.musicplayer.models
 
+import java.io.File
 import java.util.*
 
 class Events {
+    class SetPlaylistList internal constructor(val playlistNames: List<String>)
+
+    class SongDownloaded internal constructor(val path: File, val playlistName: String)
+
     class SongChanged internal constructor(val song: Song?)
 
     class SongStateChanged internal constructor(val isPlaying: Boolean)


### PR DESCRIPTION
This includes a few changes:

- Adjust app to store its files in internal storage, not "external" storage,
  i.e. SD card (or emulated SD card).

- Use MediaMetadataRetriever, not the Android MediaStore, so that we can
  reliably get metadata from non-"external" storage.

- Do post-download database I/O via event-passing. This turned out not to be important,
  but arguably it's nice to have it all in one place, or something.

- Remove unneeded COL_PLAYLIST_DOWNLOADED string.

- Create addSongsToSpecificPlaylist() helper method, so that we can add
  songs specifically to a playlist.