### PR TITLE
Add support for production data

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/activities/SettingsActivity.kt
@@ -3,9 +3,11 @@ package com.simplemobiletools.musicplayer.activities
 import android.content.Intent
 import android.os.Bundle
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
+import com.simplemobiletools.commons.extensions.toast
 import com.simplemobiletools.commons.extensions.updateTextColors
 import com.simplemobiletools.commons.models.RadioItem
 import com.simplemobiletools.musicplayer.R
+import com.simplemobiletools.musicplayer.dialogs.PasswordEntryDialog
 import com.simplemobiletools.musicplayer.extensions.config
 import com.simplemobiletools.musicplayer.extensions.sendIntent
 import com.simplemobiletools.musicplayer.helpers.FORCE_REFRESH
@@ -26,6 +28,7 @@ class SettingsActivity : SimpleActivity() {
         setupEqualizer()
         setupDevelopment()
         setupForceRefresh()
+        setupStorePassword()
         updateTextColors(settings_scrollview)
     }
 
@@ -43,8 +46,8 @@ class SettingsActivity : SimpleActivity() {
 
     private fun setupDevelopment() {
         val items = arrayListOf(
-            RadioItem(0, "No"),
-            RadioItem(1, "Yes")
+                RadioItem(0, "No"),
+                RadioItem(1, "Yes")
         )
         settings_development.text = items[config.development].title
         settings_development_holder.setOnClickListener {
@@ -56,9 +59,25 @@ class SettingsActivity : SimpleActivity() {
     }
 
 
-     private fun setupForceRefresh() {
+    private fun setupForceRefresh() {
         settings_force_refresh_holder.setOnClickListener {
             sendIntent(FORCE_REFRESH)
+        }
+    }
+
+    private fun setupStorePassword() {
+        settings_store_password_holder.setOnClickListener {
+            val currentPassword = config.currentPassword
+            PasswordEntryDialog(this@SettingsActivity, currentPassword) {
+                val newPassword = it.toLowerCase().replace(" ", "")
+                if (it == "") {
+                    toast("OK! Using sample data.")
+                    config.development = 1
+                } else if (it != currentPassword) {
+                    config.currentPassword = newPassword
+                    toast("Saved password.")
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/PasswordEntryDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/dialogs/PasswordEntryDialog.kt
@@ -1,0 +1,36 @@
+package com.simplemobiletools.musicplayer.dialogs
+
+import android.app.Activity
+import android.content.Context
+import android.support.v7.app.AlertDialog
+import android.view.WindowManager
+import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.commons.extensions.toast
+import com.simplemobiletools.commons.extensions.value
+import com.simplemobiletools.musicplayer.R
+import com.simplemobiletools.musicplayer.extensions.dbHelper
+import com.simplemobiletools.musicplayer.models.Playlist
+import kotlinx.android.synthetic.main.dialog_edit_password.view.*
+
+class PasswordEntryDialog(val activity: Activity, var currentPassword: String, val callback: (newPassword: String) -> Unit) : AlertDialog.Builder(activity) {
+    init {
+        val view = activity.layoutInflater.inflate(R.layout.dialog_edit_password, null).apply {
+            edit_password_text.setText(currentPassword)
+        }
+        AlertDialog.Builder(activity)
+                .setPositiveButton(R.string.ok, null)
+                .setNegativeButton(R.string.cancel, null)
+                .create().apply {
+            window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+            activity.setupDialogStuff(view, this, R.string.set_password)
+            getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener({
+                val newPassword = view.edit_password_text.value
+                val currentPassword = currentPassword
+                val isPasswordChanged = (newPassword != currentPassword)
+
+                callback(newPassword)
+                dismiss()
+            })
+        }
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Config.kt
@@ -35,4 +35,9 @@ class Config(context: Context) : BaseConfig(context) {
     var repeatSong: Boolean
         get() = prefs.getBoolean(REPEAT_SONG, false)
         set(repeat) = prefs.edit().putBoolean(REPEAT_SONG, repeat).apply()
+
+    var currentPassword: String
+        get() = prefs.getString(CURRENT_PASSWORD, "")
+        set(currentPassword) = prefs.edit().putString(CURRENT_PASSWORD, currentPassword).apply()
+
 }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/Constants.kt
@@ -29,6 +29,7 @@ val DEVELOPMENT = "development"
 val REPEAT_SONG = "repeat_song"
 val CURRENT_PLAYLIST = "current_playlist"
 val WAS_INITIAL_PLAYLIST_FILLED = "was_initial_playlist_filled"
+val CURRENT_PASSWORD = "current_password"
 
 // sorting
 val SORT_BY_TITLE = 1

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/DBHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/helpers/DBHelper.kt
@@ -131,6 +131,8 @@ class DBHelper private constructor(val context: Context) : SQLiteOpenHelper(cont
         } finally {
             cursor?.close()
         }
+        // re-order them in Choir order :)
+        playlists.sortWith(compareBy({! it.title.startsWith("Soprano")}, { ! it.title.startsWith("Alto") }, { ! it.title.startsWith("Tenor") },{! it.title.startsWith("Bass")}, {it.title}))
         callback(playlists)
     }
 
@@ -227,8 +229,8 @@ class DBHelper private constructor(val context: Context) : SQLiteOpenHelper(cont
                 metaRetriever.setDataSource(path)
                 val duration = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
                 val dur = java.lang.Integer.parseInt(duration) / 1000
-                val title = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
-                val artist = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
+                val title = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE) ?: path
+                val artist = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST) ?: ""
                 songs.add(Song(0, title, artist, path, dur))
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/musicplayer/services/MusicService.kt
@@ -20,6 +20,7 @@ import android.telephony.PhoneStateListener
 import android.telephony.TelephonyManager
 import android.util.Log
 import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -272,6 +273,7 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
                 mBus!!.post(Events.SongDownloaded(destination, it))
             }
         }
+        FuelManager.instance.baseHeaders = mapOf("Authorization" to config.currentPassword)
         Fuel.download(song.url)
                 .destination { response, url ->
                     destination
@@ -294,10 +296,11 @@ class MusicService : Service(), MediaPlayer.OnPreparedListener, MediaPlayer.OnEr
         val url = if (config.development == 1) {
             "https://paulproteus.github.io/sample-choir-data/data.json";
         } else {
-            "okay"
+            "https://d3lci55r7d8wre.cloudfront.net/data.json"
         }
 
         // Get the JSON metadata first.
+        FuelManager.instance.baseHeaders = mapOf("Authorization" to config.currentPassword)
         Fuel.get(url).
                 responseObject(ChoirDataResponse.Deserializer()) { request, _, result ->
                     result.fold(success = { response ->

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -138,5 +138,25 @@
                 android:paddingRight="@dimen/medium_margin"
                 android:text="Development: Force refresh of choir data"/>
         </RelativeLayout>
+        <RelativeLayout
+            android:id="@+id/settings_store_password_holder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:background="?attr/selectableItemBackground"
+            android:paddingBottom="@dimen/bigger_margin"
+            android:paddingLeft="@dimen/activity_margin"
+            android:paddingRight="@dimen/activity_margin"
+            android:paddingTop="@dimen/bigger_margin">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_store_password_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:paddingLeft="@dimen/medium_margin"
+                android:paddingRight="@dimen/medium_margin"
+                android:text="Development: Enter choir password"/>
+        </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_edit_password.xml
+++ b/app/src/main/res/layout/dialog_edit_password.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/new_playlist_dialog_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/activity_margin"
+    android:paddingRight="@dimen/activity_margin"
+    android:paddingTop="@dimen/activity_margin">
+
+    <com.simplemobiletools.commons.views.MyEditText
+        android:id="@+id/edit_password_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/activity_margin"
+        android:layout_marginLeft="@dimen/small_margin"
+        android:layout_marginStart="@dimen/small_margin"
+        android:inputType="textCapSentences"
+        android:maxLength="50"
+        android:singleLine="true"
+        android:textCursorDrawable="@null"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
 
     <!-- Settings -->
     <string name="equalizer">Equalizer</string>
+    <string name="set_password">Set the password</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- Short description has to have less than 80 chars -->


### PR DESCRIPTION
This entails:

- Adding a UI for configuring a password, within Settings; thread this through to
  FuelManager.

- Auto-indent SettingsActivity.kt, resulting in some whitespace noise.

Also:

- Permit empty TITLE and ARTIST from metadata retriever (treat them as "")

- Show playlists in Choir order :)